### PR TITLE
Storage for registered websockets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "websockets-notification-py"
 version = "0.0.1"
+requires-python = ">=3.12"
 dependencies = [
     "websockets",
     "aio-pika",
@@ -32,7 +33,6 @@ dev = [
 
 [tool.ruff]
 line-length = 160
-target-version = "py312"
 
 
 [tool.roof.lint]

--- a/src/a12n/jwk_client.py
+++ b/src/a12n/jwk_client.py
@@ -12,7 +12,9 @@ from jwt.exceptions import PyJWKSetError
 from jwt.jwk_set_cache import JWKSetCache
 
 
-from a12n.types import DecodedValidToken
+
+from app.types import DecodedValidToken
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/a12n/jwk_client.py
+++ b/src/a12n/jwk_client.py
@@ -12,7 +12,6 @@ from jwt.exceptions import PyJWKSetError
 from jwt.jwk_set_cache import JWKSetCache
 
 
-
 from app.types import DecodedValidToken
 
 

--- a/src/a12n/types.py
+++ b/src/a12n/types.py
@@ -1,6 +1,0 @@
-from typing import NamedTuple
-
-
-class DecodedValidToken(NamedTuple):
-    sub: str
-    exp: int

--- a/src/app/services.py
+++ b/src/app/services.py
@@ -1,0 +1,43 @@
+from abc import ABC
+from abc import abstractmethod
+from typing import Any, Callable
+
+
+class BaseService(ABC):
+    """This is a template of a a base service.
+    All services in the app should follow this rules:
+      * Input variables should be done at the __init__ phase
+      * Service should implement a single entrypoint without arguments
+
+    This is ok:
+      @dataclass
+      class UserCreator(BaseService):
+        first_name: str
+        last_name: str | None
+
+        def act(self) -> User:
+          return User.objects.create(first_name=self.first_name, last_name=self.last_name)
+
+        # user = UserCreator(first_name="Ivan", last_name="Petrov")()
+
+    This is not ok:
+      class UserCreator:
+        def __call__(self, first_name: str, last_name: Optional[str]) -> User:
+          return User.objects.create(first_name=self.first_name, last_name=self.last_name)
+    """
+
+    def __call__(self) -> Any:
+        self.validate()
+        return self.act()
+
+    def get_validators(self) -> list[Callable]:
+        return []
+
+    def validate(self) -> None:
+        validators = self.get_validators()
+        for validator in validators:
+            validator()
+
+    @abstractmethod
+    def act(self) -> Any:
+        raise NotImplementedError("Please implement in the service class")

--- a/src/app/testing.py
+++ b/src/app/testing.py
@@ -1,0 +1,62 @@
+import asyncio
+import json
+from uuid import uuid4
+
+import websockets
+from websockets.frames import CloseCode
+from websockets.protocol import State
+
+
+class MockedWebSocketServerProtocol(websockets.WebSocketServerProtocol):
+    """Websocket Server connection implementation for testing purpose.
+
+    To send and receive messages on the client, use the 'client_send' and 'client_recv' methods.
+    These methods store messages in appropriate queues but do not actually send them to the client
+    """
+
+    def __init__(self) -> None:
+        self.id = uuid4()
+
+        self.send_queue: asyncio.Queue[str] = asyncio.Queue(0)
+        self.recv_queue: asyncio.Queue[str] = asyncio.Queue(0)
+
+        # Used by websockets to track connection state
+        self.state = State.OPEN
+
+    async def recv(self) -> str | bytes:
+        if self.state == State.CLOSED:
+            raise websockets.ConnectionClosedOK(rcvd=None, sent=None)
+
+        return await self.recv_queue.get()
+
+    async def send(self, message: str) -> None:  # type: ignore[override]
+        await asyncio.sleep(0)
+        await self.send_queue.put(message)
+
+    async def close(self, code: int = CloseCode.NORMAL_CLOSURE, reason: str = "") -> None:
+        self.state = State.CLOSED
+
+    async def wait_messages_to_be_sent(self) -> None:
+        await asyncio.sleep(0.1)  # to get enough time to receive messages in coroutines tasks
+
+    async def count_sent_to_client(self) -> int:
+        await self.wait_messages_to_be_sent()
+        return self.send_queue.qsize()
+
+    def client_send(self, message: dict) -> None:
+        self.recv_queue.put_nowait(json.dumps(message))
+
+    async def client_recv(self, skip_count_first_messages=0) -> dict | None:
+        """Convenient for testing.
+        Receive one message at time. First messages could be discarded with 'skip_count_first_messages' parameter.
+        """
+        await self.wait_messages_to_be_sent()
+
+        if self.send_queue.empty():
+            return None
+
+        while skip_count_first_messages:
+            self.send_queue.get_nowait()
+            skip_count_first_messages -= 1
+
+        return json.loads(self.send_queue.get_nowait())

--- a/src/app/types.py
+++ b/src/app/types.py
@@ -2,7 +2,6 @@ from typing import NewType, NamedTuple
 
 UserId = NewType("UserId", str)
 Event = NewType("Event", str)
-BrokerRoutingKey = NewType("BrokerRoutingKey", str)
 
 
 class DecodedValidToken(NamedTuple):

--- a/src/app/types.py
+++ b/src/app/types.py
@@ -1,0 +1,10 @@
+from typing import NewType, NamedTuple
+
+UserId = NewType("UserId", str)
+Event = NewType("Event", str)
+BrokerRoutingKey = NewType("BrokerRoutingKey", str)
+
+
+class DecodedValidToken(NamedTuple):
+    sub: UserId
+    exp: int

--- a/src/storage/__init__.py
+++ b/src/storage/__init__.py
@@ -1,0 +1,5 @@
+from storage.subscription_storage import SubscriptionStorage
+
+__all__ = [
+    "SubscriptionStorage",
+]

--- a/src/storage/exceptions.py
+++ b/src/storage/exceptions.py
@@ -1,0 +1,2 @@
+class StorageOperationException(Exception):
+    """Raise if storage operation could not be performed."""

--- a/src/storage/storage_updaters/__init__.py
+++ b/src/storage/storage_updaters/__init__.py
@@ -1,0 +1,11 @@
+from storage.storage_updaters.storage_connection_register import StorageConnectionRegister
+from storage.storage_updaters.storage_connection_remover import StorageConnectionRemover
+from storage.storage_updaters.storage_user_subscriber import StorageUserSubscriber
+from storage.storage_updaters.storage_user_unsubscriber import StorageUserUnsubscriber
+
+__all__ = [
+    "StorageConnectionRegister",
+    "StorageUserSubscriber",
+    "StorageUserUnsubscriber",
+    "StorageConnectionRemover",
+]

--- a/src/storage/storage_updaters/storage_connection_register.py
+++ b/src/storage/storage_updaters/storage_connection_register.py
@@ -1,0 +1,82 @@
+from dataclasses import dataclass
+from functools import cached_property
+import logging
+from typing import cast
+
+from websockets.server import WebSocketServerProtocol
+
+from app.services import BaseService
+from app.types import DecodedValidToken
+from app.types import UserId
+from storage.exceptions import StorageOperationException
+from storage.subscription_storage import SubscriptionStorage
+from storage.types import ConnectedUserMeta
+from storage.types import WebSocketMeta
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class StorageConnectionRegister(BaseService):
+    """Add or update websocket in storage
+
+    If websocket not registered: just register it.
+
+    If websocket is registered already:
+        - if token's 'user_id' is the same then update websocket's expiration timestamp
+        - if token's 'user_id' is different then do not change existed registered websocket and raise `StorageOperationException`
+    """
+
+    storage: SubscriptionStorage
+    websocket: WebSocketServerProtocol
+    validated_token: DecodedValidToken
+
+    @cached_property
+    def existed_websocket_meta(self) -> WebSocketMeta | None:
+        return self.storage.registered_websockets.get(self.websocket)
+
+    @cached_property
+    def token_user_id(self) -> UserId:
+        return self.validated_token.sub
+
+    @cached_property
+    def token_expiration_timestamp(self) -> int:
+        return self.validated_token.exp
+
+    def act(self) -> None:
+        self.validate_token_user_id()
+
+        if self.existed_websocket_meta:
+            self.update_registered_websocket_meta(self.existed_websocket_meta)
+            return None
+
+        self.register_new_websocket()
+
+    def validate_token_user_id(self) -> None:
+        if self.existed_websocket_meta and self.existed_websocket_meta.user_id != self.token_user_id:
+            logger.warning("The user with id '%s' provided token of user of id '%s'", self.existed_websocket_meta.user_id, self.token_user_id)
+            raise StorageOperationException("The user has different public id")
+
+    def update_registered_websocket_meta(self, websocket_meta: WebSocketMeta) -> None:
+        websocket_meta.expiration_timestamp = self.token_expiration_timestamp
+        logger.info("The expiration time for ws with id '%s' was updated to '%s'", str(self.websocket.id), self.token_expiration_timestamp)
+
+    def register_new_websocket(self) -> None:
+        self.add_new_websocket_to_registered_websockets()
+        self.add_new_websocket_to_user_connections()
+
+    def add_new_websocket_to_registered_websockets(self) -> None:
+        self.storage.registered_websockets[self.websocket] = WebSocketMeta(
+            user_id=self.token_user_id,
+            expiration_timestamp=self.token_expiration_timestamp,
+        )
+
+    def add_new_websocket_to_user_connections(self) -> None:
+        user_connections = self.storage.user_connections.get(self.token_user_id)
+
+        if user_connections:
+            user_connections.websockets.append(self.websocket)
+            logger.info("The user with id '%s' has new websocket connection", self.token_user_id)
+        else:
+            self.storage.user_connections[self.token_user_id] = ConnectedUserMeta(websockets=[self.websocket], user_subscriptions=set())
+            logger.info("The user with id '%s' registered with first websocket connection", self.token_user_id)

--- a/src/storage/storage_updaters/storage_connection_register.py
+++ b/src/storage/storage_updaters/storage_connection_register.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from functools import cached_property
 import logging
-from typing import cast
 
 from websockets.server import WebSocketServerProtocol
 

--- a/src/storage/storage_updaters/storage_connection_remover.py
+++ b/src/storage/storage_updaters/storage_connection_remover.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass
+import logging
+
+from websockets.server import WebSocketServerProtocol
+
+from app.services import BaseService
+from app.types import UserId
+from storage.storage_updaters.storage_user_unsubscriber import StorageUserSubscriptionRemover
+from storage.subscription_storage import SubscriptionStorage
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class StorageConnectionRemover(BaseService):
+    """ "Remove connection from storage.
+
+    If websocket is not registered then nothing to do.
+    If websocket is registered and it's last connection then unsubscribe user from all subscriptions.
+    If websocket is registered and other user websocket exists then just remove the websocket from user connections and keep user subscriptions.
+    """
+
+    storage: SubscriptionStorage
+    websocket: WebSocketServerProtocol
+
+    def act(self) -> None:
+        user_id = self.storage.get_websocket_user_id(self.websocket)
+
+        if not user_id:
+            logger.info("Removing not registered connection with id = '%s', nothing to do with storage", str(self.websocket.id))
+            return
+
+        if self.is_last_user_websocket(user_id):
+            self.remove_user_subscriptions(user_id)
+            self.remove_user_connections(user_id)
+        else:
+            self.remove_websocket_from_user_connections(user_id)
+
+        self.remove_websocket_from_registered_websockets()
+
+    def is_last_user_websocket(self, user_id: UserId) -> bool:
+        return len(self.storage.user_connections[user_id].websockets) == 1
+
+    def remove_user_subscriptions(self, user_id: UserId) -> None:
+        user_connection_fqis = self.storage.user_connections[user_id].user_subscriptions.copy()
+
+        for subscription_fqi in user_connection_fqis:
+            StorageUserSubscriptionRemover(self.storage, user_id, subscription_fqi)()
+
+    def remove_user_connections(self, user_id: UserId) -> None:
+        del self.storage.user_connections[user_id]
+        logger.info("The last connection for user removed from storage. User ID: '%s'", user_id)
+
+    def remove_websocket_from_user_connections(self, user_id: UserId) -> None:
+        self.storage.user_connections[user_id].websockets.remove(self.websocket)
+        logger.info("Websocket removed form user connections. UserId: `%s`, WebsocketId: `%s`", user_id, str(self.websocket.id))
+
+    def remove_websocket_from_registered_websockets(self) -> None:
+        del self.storage.registered_websockets[self.websocket]
+        logger.info("Websocket removed from registered websockets. Websocket ID: `%s`", str(self.websocket.id))

--- a/src/storage/storage_updaters/storage_user_subscriber.py
+++ b/src/storage/storage_updaters/storage_user_subscriber.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+from functools import cached_property
+import logging
+
+from websockets.server import WebSocketServerProtocol
+
+from app.services import BaseService
+from app.types import UserId
+from storage.exceptions import StorageOperationException
+from storage.subscription_storage import SubscriptionStorage
+from storage.types import SubscriptionFullQualifiedIdentifier
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class StorageUserSubscriber(BaseService):
+    storage: SubscriptionStorage
+    websocket: WebSocketServerProtocol
+    subscription_fqi: SubscriptionFullQualifiedIdentifier
+
+    @cached_property
+    def websocket_user_id(self) -> UserId:
+        user_id = self.storage.get_websocket_user_id(self.websocket)
+
+        if not user_id:
+            raise StorageOperationException("The user is not registered")
+
+        return user_id
+
+    def act(self) -> None:
+        self.update_storage_subscriptions()
+        self.update_user_subscriptions()
+
+    def update_storage_subscriptions(self) -> None:
+        event, _, event_subscription_identifier = self.subscription_fqi
+
+        # Create event with events_subscriptions_storage if it's the first subscription for the event
+        if event not in self.storage.subscriptions:
+            self.storage.subscriptions[event] = {}
+            logger.info("Event record for subscriptions created in storage. Event: '%s'", event)
+
+        event_subscriptions = self.storage.subscriptions[event]
+
+        # Create subscription identifier in event subscription storage if it doesn't exist
+        if event_subscription_identifier not in event_subscriptions:
+            event_subscriptions[event_subscription_identifier] = set()
+            logger.info("Subscription identifier created for event. Event: '%s', Identifier '%s'", event, event_subscription_identifier)
+
+        event_subscriptions[event_subscription_identifier].add(self.websocket_user_id)
+        logger.info("User added to event subscribers. UserId: '%s', subscription_fqi: '%s'", self.websocket_user_id, self.subscription_fqi)
+
+    def update_user_subscriptions(self) -> None:
+        self.storage.user_connections[self.websocket_user_id].user_subscriptions.add(self.subscription_fqi)
+        logger.info("Subscription added to user: '%s', subscription_fqi: '%s'", self.websocket_user_id, self.subscription_fqi)

--- a/src/storage/storage_updaters/storage_user_subscriber.py
+++ b/src/storage/storage_updaters/storage_user_subscriber.py
@@ -29,8 +29,13 @@ class StorageUserSubscriber(BaseService):
         return user_id
 
     def act(self) -> None:
+        self.validate_websocket_registered()
+
         self.update_storage_subscriptions()
         self.update_user_subscriptions()
+
+    def validate_websocket_registered(self) -> UserId:
+        return self.websocket_user_id  # access to property
 
     def update_storage_subscriptions(self) -> None:
         event, _, event_subscription_identifier = self.subscription_fqi

--- a/src/storage/storage_updaters/storage_user_unsubscriber.py
+++ b/src/storage/storage_updaters/storage_user_unsubscriber.py
@@ -1,0 +1,72 @@
+from dataclasses import dataclass
+from functools import cached_property
+import logging
+
+from websockets.server import WebSocketServerProtocol
+
+from app.services import BaseService
+from app.types import UserId
+from storage.exceptions import StorageOperationException
+from storage.subscription_storage import SubscriptionStorage
+from storage.types import SubscriptionFullQualifiedIdentifier
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class StorageUserUnsubscriber(BaseService):
+    storage: SubscriptionStorage
+    websocket: WebSocketServerProtocol
+    subscription_fqi: SubscriptionFullQualifiedIdentifier
+
+    @cached_property
+    def websocket_user_id(self) -> UserId:
+        user_id = self.storage.get_websocket_user_id(self.websocket)
+
+        if not user_id:
+            raise StorageOperationException("The user is not authenticated")
+
+        return user_id
+
+
+    def act(self) -> None:
+        if self.is_user_has_subscription():
+            StorageUserSubscriptionRemover(
+                self.storage,
+                self.websocket_user_id,
+                self.subscription_fqi,
+            )()
+
+    def is_user_has_subscription(self) -> bool:
+        return self.subscription_fqi in self.storage.user_connections[self.websocket_user_id].user_subscriptions
+
+
+@dataclass
+class StorageUserSubscriptionRemover(BaseService):
+    storage: SubscriptionStorage
+    user_id: UserId
+    subscription_fqi: SubscriptionFullQualifiedIdentifier
+
+    def act(self) -> None:
+        self.remove_storage_subscription()
+        self.update_user_subscriptions()
+
+    def remove_storage_subscription(self) -> None:
+        event, _, event_subscription_identifier = self.subscription_fqi
+
+        event_subscriptions = self.storage.subscriptions[event]
+
+        event_subscriptions[event_subscription_identifier].discard(self.user_id)
+        logger.info("User unsubscribed from event. User: '%s', subscription_fqi '%s'", self.user_id, self.subscription_fqi)
+
+        if not event_subscriptions[event_subscription_identifier]:
+            del event_subscriptions[event_subscription_identifier]
+            logger.info("Subscription identifier removed from event in storage. Event: '%s', identifier: '%s'", event, event_subscription_identifier)
+
+        if not self.storage.subscriptions[event]:
+            del self.storage.subscriptions[event]
+            logger.info("Event from storage removed cause empty. Event: '%s'", event)
+
+    def update_user_subscriptions(self) -> None:
+        self.storage.user_connections[self.user_id].user_subscriptions.discard(self.subscription_fqi)
+        logger.info("Subscription removed from user. User: '%s', subscription_fqi: '%s'", self.user_id, self.subscription_fqi)

--- a/src/storage/storage_updaters/storage_user_unsubscriber.py
+++ b/src/storage/storage_updaters/storage_user_unsubscriber.py
@@ -24,10 +24,9 @@ class StorageUserUnsubscriber(BaseService):
         user_id = self.storage.get_websocket_user_id(self.websocket)
 
         if not user_id:
-            raise StorageOperationException("The user is not authenticated")
+            raise StorageOperationException("The user is not registered")
 
         return user_id
-
 
     def act(self) -> None:
         if self.is_user_has_subscription():

--- a/src/storage/subscription_storage.py
+++ b/src/storage/subscription_storage.py
@@ -48,8 +48,4 @@ class SubscriptionStorage:
     def get_expired_websockets(self) -> list[WebSocketServerProtocol]:
         now_timestamp = time.time()
 
-        return [
-            websocket
-            for websocket, websocket_meta in self.registered_websockets.items()
-            if websocket_meta.expiration_timestamp <= now_timestamp
-        ]
+        return [websocket for websocket, websocket_meta in self.registered_websockets.items() if websocket_meta.expiration_timestamp <= now_timestamp]

--- a/src/storage/subscription_storage.py
+++ b/src/storage/subscription_storage.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+from dataclasses import field
+import time
+
+from websockets import WebSocketServerProtocol
+
+from app.types import Event
+from app.types import UserId
+from storage.types import ConnectedUserMeta
+from storage.types import WebSocketMeta
+from storage.types import EventSubscriptionIdentifier
+from storage.types import EventSubscriptionsBucket
+
+
+@dataclass
+class SubscriptionStorage:
+    registered_websockets: dict[WebSocketServerProtocol, WebSocketMeta] = field(default_factory=dict)
+    subscriptions: dict[Event, EventSubscriptionsBucket] = field(default_factory=dict)
+    user_connections: dict[UserId, ConnectedUserMeta] = field(default_factory=dict)
+
+    def is_websocket_registered(self, websocket: WebSocketServerProtocol) -> bool:
+        return websocket in self.registered_websockets
+
+    def get_registered_websockets(self) -> list[WebSocketServerProtocol]:
+        return list(self.registered_websockets.keys())
+
+    def get_websocket_user_id(self, websocket: WebSocketServerProtocol) -> UserId | None:
+        websocket_meta = self.registered_websockets.get(websocket)
+        return websocket_meta.user_id if websocket_meta else None
+
+    def get_event_subscribers_user_ids(self, event: Event, identifier: EventSubscriptionIdentifier) -> set[UserId]:
+        return self.subscriptions.get(event, {}).get(identifier, set())
+
+    def is_event_active(self, event: Event) -> bool:
+        return event in self.subscriptions
+
+    def get_users_websockets(self, user_ids: set[UserId]) -> list[WebSocketServerProtocol]:
+        users_websockets = []
+
+        for user_id in user_ids:
+            user_connection_meta = self.user_connections.get(user_id)
+
+            if user_connection_meta:
+                users_websockets.extend(user_connection_meta.websockets)
+
+        return users_websockets
+
+    def get_expired_websockets(self) -> list[WebSocketServerProtocol]:
+        now_timestamp = time.time()
+
+        return [
+            websocket
+            for websocket, websocket_meta in self.registered_websockets.items()
+            if websocket_meta.expiration_timestamp <= now_timestamp
+        ]

--- a/src/storage/tests/conftest.py
+++ b/src/storage/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from storage import SubscriptionStorage
+
+
+@pytest.fixture
+def storage():
+    return SubscriptionStorage()

--- a/src/storage/tests/storage_updaters/conftest.py
+++ b/src/storage/tests/storage_updaters/conftest.py
@@ -1,0 +1,82 @@
+import pytest
+
+from app.types import DecodedValidToken
+from app.testing import MockedWebSocketServerProtocol
+from storage.storage_updaters.storage_connection_register import StorageConnectionRegister
+from storage.storage_updaters.storage_user_subscriber import StorageUserSubscriber
+from storage.types import SubscriptionFullQualifiedIdentifier
+
+
+@pytest.fixture
+def valid_token():
+    return DecodedValidToken(sub="user1", exp=4700000000)  # year of expiration 2118
+
+
+@pytest.fixture
+def ya_valid_token():
+    return DecodedValidToken(sub="user1", exp=5700000000)
+
+
+@pytest.fixture
+def ya_user_valid_token():
+    return DecodedValidToken(sub="user2", exp=7700000000)
+
+
+@pytest.fixture
+def ws_connection():
+    return MockedWebSocketServerProtocol()
+
+
+@pytest.fixture
+def ya_ws_connection():
+    return MockedWebSocketServerProtocol()
+
+
+@pytest.fixture
+def authenticate_ws(storage):
+    def authenticate(ws_connection, token):
+        StorageConnectionRegister(storage, ws_connection, token)()
+
+    return authenticate
+
+
+@pytest.fixture
+def ws_authenticated(ws_connection, valid_token, authenticate_ws):
+    authenticate_ws(ws_connection, valid_token)
+    return ws_connection
+
+
+@pytest.fixture
+def event():
+    return "omniNotification"
+
+
+@pytest.fixture
+def event_subscription_key():
+    return ("userId",)
+
+
+@pytest.fixture
+def event_subscription_identifier():
+    return ("userX",)
+
+
+@pytest.fixture
+def subscription_fqi(event, event_subscription_key, event_subscription_identifier):
+    return SubscriptionFullQualifiedIdentifier(
+        event=event,
+        subscription_key=event_subscription_key,
+        subscription_identifier=event_subscription_identifier,
+    )
+
+
+@pytest.fixture
+def subscribe_ws(storage):
+    def subscribe(ws_connection, subscription_fqi):
+        StorageUserSubscriber(
+            storage=storage,
+            websocket=ws_connection,
+            subscription_fqi=subscription_fqi,
+        )()
+
+    return subscribe

--- a/src/storage/tests/storage_updaters/conftest.py
+++ b/src/storage/tests/storage_updaters/conftest.py
@@ -23,27 +23,27 @@ def ya_user_valid_token():
 
 
 @pytest.fixture
-def ws_connection():
+def ws():
     return MockedWebSocketServerProtocol()
 
 
 @pytest.fixture
-def ya_ws_connection():
+def ya_ws():
     return MockedWebSocketServerProtocol()
 
 
 @pytest.fixture
-def authenticate_ws(storage):
-    def authenticate(ws_connection, token):
-        StorageConnectionRegister(storage, ws_connection, token)()
+def register_ws(storage):
+    def register(ws, token):
+        StorageConnectionRegister(storage, ws, token)()
 
-    return authenticate
+    return register
 
 
 @pytest.fixture
-def ws_authenticated(ws_connection, valid_token, authenticate_ws):
-    authenticate_ws(ws_connection, valid_token)
-    return ws_connection
+def ws_registered(ws, valid_token, register_ws):
+    register_ws(ws, valid_token)
+    return ws
 
 
 @pytest.fixture
@@ -72,11 +72,17 @@ def subscription_fqi(event, event_subscription_key, event_subscription_identifie
 
 @pytest.fixture
 def subscribe_ws(storage):
-    def subscribe(ws_connection, subscription_fqi):
+    def subscribe(ws, subscription_fqi):
         StorageUserSubscriber(
             storage=storage,
-            websocket=ws_connection,
+            websocket=ws,
             subscription_fqi=subscription_fqi,
         )()
 
     return subscribe
+
+
+@pytest.fixture
+def ws_subscribed(ws_registered, subscribe_ws, subscription_fqi):
+    subscribe_ws(ws_registered, subscription_fqi)
+    return ws_registered

--- a/src/storage/tests/storage_updaters/tests_storage_connection_register.py
+++ b/src/storage/tests/storage_updaters/tests_storage_connection_register.py
@@ -9,57 +9,55 @@ from storage.types import WebSocketMeta
 
 @pytest.fixture
 def register(storage: SubscriptionStorage):
-    return lambda ws_connection, token: StorageConnectionRegister(
+    return lambda ws, token: StorageConnectionRegister(
         storage=storage,
-        websocket=ws_connection,
+        websocket=ws,
         validated_token=token,
     )()
 
 
-def test_register_new_websocket_in_storage(storage, register, ws_connection, valid_token):
-    register(ws_connection, valid_token)
+def test_register_new_websocket_in_storage(storage, register, ws, valid_token):
+    register(ws, valid_token)
 
-    assert ws_connection in storage.registered_websockets
-    assert storage.registered_websockets[ws_connection] == WebSocketMeta(user_id="user1", expiration_timestamp=4700000000)
-    assert storage.user_connections["user1"] == ConnectedUserMeta(websockets=[ws_connection], user_subscriptions=set())
-
-
-def test_if_existed_connection_then_update_connection_expiration_time(register, ws_connection, valid_token, ya_valid_token, storage):
-    register(ws_connection, valid_token)
-
-    register(ws_connection, ya_valid_token)
-
-    assert ws_connection in storage.registered_connections
-    assert storage.registered_connections[ws_connection] == WebSocketMeta(user_id="user1", expiration_timestamp=5700000000)
+    assert ws in storage.registered_websockets
+    assert storage.registered_websockets[ws] == WebSocketMeta(user_id="user1", expiration_timestamp=4700000000)
+    assert storage.user_connections["user1"] == ConnectedUserMeta(websockets=[ws], user_subscriptions=set())
 
 
-def test_raise_if_update_connection_with_token_from_another_user(register, storage, ws_connection, valid_token, ya_user_valid_token):
-    register(ws_connection, valid_token)
+def test_if_existed_websocket_then_update_its_expiration_time(register, ws, valid_token, ya_valid_token, storage):
+    register(ws, valid_token)
+
+    register(ws, ya_valid_token)
+
+    assert ws in storage.registered_websockets
+    assert storage.registered_websockets[ws] == WebSocketMeta(user_id="user1", expiration_timestamp=5700000000)
+
+
+def test_raise_if_update_websocket_with_token_from_another_user(register, storage, ws, valid_token, ya_user_valid_token):
+    register(ws, valid_token)
 
     with pytest.raises(StorageOperationException, match="The user has different public id"):
-        register(ws_connection, ya_user_valid_token)
+        register(ws, ya_user_valid_token)
 
-    assert storage.registered_connections[ws_connection] == WebSocketMeta(
-        user_id="user1", expiration_timestamp=4700000000
-    ), "Existed connection should not change"
+    assert storage.registered_websockets[ws] == WebSocketMeta(user_id="user1", expiration_timestamp=4700000000), "Should not change registered meta"
 
 
-def test_user_registration_do_not_touch_other_user_connections(register, ws_connection, ya_ws_connection, storage, valid_token, ya_user_valid_token):
-    register(ws_connection, valid_token)
+def test_user_registration_do_not_touch_other_users(register, ws, ya_ws, storage, valid_token, ya_user_valid_token):
+    register(ws, valid_token)
 
-    register(ya_ws_connection, ya_user_valid_token)
+    register(ya_ws, ya_user_valid_token)
 
-    assert storage.registered_connections[ws_connection] == WebSocketMeta(user_id="user1", expiration_timestamp=4700000000)
-    assert storage.registered_connections[ya_ws_connection] == WebSocketMeta(user_id="user2", expiration_timestamp=7700000000)
-    assert storage.user_connections["user1"] == ConnectedUserMeta([ws_connection], set())
-    assert storage.user_connections["user2"] == ConnectedUserMeta([ya_ws_connection], set())
+    assert storage.registered_websockets[ws] == WebSocketMeta(user_id="user1", expiration_timestamp=4700000000)
+    assert storage.registered_websockets[ya_ws] == WebSocketMeta(user_id="user2", expiration_timestamp=7700000000)
+    assert storage.user_connections["user1"] == ConnectedUserMeta([ws], set())
+    assert storage.user_connections["user2"] == ConnectedUserMeta([ya_ws], set())
 
 
-def test_same_user_other_websocket_added_ok(register, ws_connection, ya_ws_connection, storage, valid_token, ya_valid_token):
-    register(ws_connection, valid_token)
+def test_user_registered_with_second_websocket_ok(register, ws, ya_ws, storage, valid_token, ya_valid_token):
+    register(ws, valid_token)
 
-    register(ya_ws_connection, ya_valid_token)
+    register(ya_ws, ya_valid_token)
 
-    assert storage.user_connections["user1"] == ConnectedUserMeta([ws_connection, ya_ws_connection], set())
-    assert storage.registered_connections[ws_connection] == WebSocketMeta(user_id="user1", expiration_timestamp=4700000000)
-    assert storage.registered_connections[ya_ws_connection] == WebSocketMeta(user_id="user1", expiration_timestamp=5700000000)
+    assert storage.user_connections["user1"] == ConnectedUserMeta([ws, ya_ws], set())
+    assert storage.registered_websockets[ws] == WebSocketMeta(user_id="user1", expiration_timestamp=4700000000)
+    assert storage.registered_websockets[ya_ws] == WebSocketMeta(user_id="user1", expiration_timestamp=5700000000)

--- a/src/storage/tests/storage_updaters/tests_storage_connection_register.py
+++ b/src/storage/tests/storage_updaters/tests_storage_connection_register.py
@@ -1,0 +1,65 @@
+import pytest
+
+from storage.exceptions import StorageOperationException
+from storage.storage_updaters import StorageConnectionRegister
+from storage.subscription_storage import SubscriptionStorage
+from storage.types import ConnectedUserMeta
+from storage.types import WebSocketMeta
+
+
+@pytest.fixture
+def register(storage: SubscriptionStorage):
+    return lambda ws_connection, token: StorageConnectionRegister(
+        storage=storage,
+        websocket=ws_connection,
+        validated_token=token,
+    )()
+
+
+def test_register_new_websocket_in_storage(storage, register, ws_connection, valid_token):
+    register(ws_connection, valid_token)
+
+    assert ws_connection in storage.registered_websockets
+    assert storage.registered_websockets[ws_connection] == WebSocketMeta(user_id="user1", expiration_timestamp=4700000000)
+    assert storage.user_connections["user1"] == ConnectedUserMeta(websockets=[ws_connection], user_subscriptions=set())
+
+
+def test_if_existed_connection_then_update_connection_expiration_time(register, ws_connection, valid_token, ya_valid_token, storage):
+    register(ws_connection, valid_token)
+
+    register(ws_connection, ya_valid_token)
+
+    assert ws_connection in storage.registered_connections
+    assert storage.registered_connections[ws_connection] == WebSocketMeta(user_id="user1", expiration_timestamp=5700000000)
+
+
+def test_raise_if_update_connection_with_token_from_another_user(register, storage, ws_connection, valid_token, ya_user_valid_token):
+    register(ws_connection, valid_token)
+
+    with pytest.raises(StorageOperationException, match="The user has different public id"):
+        register(ws_connection, ya_user_valid_token)
+
+    assert storage.registered_connections[ws_connection] == WebSocketMeta(
+        user_id="user1", expiration_timestamp=4700000000
+    ), "Existed connection should not change"
+
+
+def test_user_registration_do_not_touch_other_user_connections(register, ws_connection, ya_ws_connection, storage, valid_token, ya_user_valid_token):
+    register(ws_connection, valid_token)
+
+    register(ya_ws_connection, ya_user_valid_token)
+
+    assert storage.registered_connections[ws_connection] == WebSocketMeta(user_id="user1", expiration_timestamp=4700000000)
+    assert storage.registered_connections[ya_ws_connection] == WebSocketMeta(user_id="user2", expiration_timestamp=7700000000)
+    assert storage.user_connections["user1"] == ConnectedUserMeta([ws_connection], set())
+    assert storage.user_connections["user2"] == ConnectedUserMeta([ya_ws_connection], set())
+
+
+def test_same_user_other_websocket_added_ok(register, ws_connection, ya_ws_connection, storage, valid_token, ya_valid_token):
+    register(ws_connection, valid_token)
+
+    register(ya_ws_connection, ya_valid_token)
+
+    assert storage.user_connections["user1"] == ConnectedUserMeta([ws_connection, ya_ws_connection], set())
+    assert storage.registered_connections[ws_connection] == WebSocketMeta(user_id="user1", expiration_timestamp=4700000000)
+    assert storage.registered_connections[ya_ws_connection] == WebSocketMeta(user_id="user1", expiration_timestamp=5700000000)

--- a/src/storage/tests/storage_updaters/tests_storage_connection_remover.py
+++ b/src/storage/tests/storage_updaters/tests_storage_connection_remover.py
@@ -5,52 +5,46 @@ from storage.storage_updaters import StorageConnectionRemover
 
 
 @pytest.fixture
-def ws_subscribed(ws_authenticated, subscribe_ws, subscription_fqi):
-    subscribe_ws(ws_authenticated, subscription_fqi)
-    return ws_authenticated
-
-
-@pytest.fixture
-def ya_user_ws_authenticated(ya_ws_connection, ya_user_valid_token, authenticate_ws):
-    authenticate_ws(ya_ws_connection, ya_user_valid_token)
-    return ya_ws_connection
+def ya_user_ws_registered(ya_ws, ya_user_valid_token, register_ws):
+    register_ws(ya_ws, ya_user_valid_token)
+    return ya_ws
 
 
 @pytest.fixture
 def remove(storage):
-    return lambda ws_connection: StorageConnectionRemover(storage, ws_connection)()
+    return lambda ws: StorageConnectionRemover(storage, ws)()
 
 
-def test_remove_connection_and_subscriptions_from_storage(remove, ws_subscribed, storage):
+def test_remove_websocket_and_user_subscriptions_from_storage(remove, ws_subscribed, storage):
     remove(ws_subscribed)
 
-    assert storage.authenticated_connections == {}
+    assert storage.registered_websockets == {}
     assert storage.user_connections == {}
     assert storage.subscriptions == {}
 
 
-def test_do_not_remove_subscriptions_if_other_user_connections_exist(remove, ws_subscribed, ya_ws_connection, storage, ya_valid_token, authenticate_ws):
-    authenticate_ws(ya_ws_connection, ya_valid_token)  # same user, other ws connection
+def test_do_not_remove_subscriptions_if_other_user_websockets_exist(remove, ws_subscribed, ya_ws, storage, ya_valid_token, register_ws):
+    register_ws(ya_ws, ya_valid_token)  # same user, other ws connection
 
     remove(ws_subscribed)
 
-    assert len(storage.authenticated_connections) == 1
-    assert ya_ws_connection in storage.authenticated_connections
-    assert storage.user_connections["user1"].connections == [ya_ws_connection]
+    assert len(storage.registered_websockets) == 1
+    assert ya_ws in storage.registered_websockets
+    assert storage.user_connections["user1"].websockets == [ya_ws]
     assert storage.user_connections["user1"].user_subscriptions
     assert len(storage.subscriptions) == 1
 
 
-def test_do_not_remove_subscriptions_other_user(remove, ws_subscribed, ya_user_ws_authenticated, storage):
-    remove(ya_user_ws_authenticated)
+def test_do_not_remove_subscriptions_other_user(remove, ws_subscribed, ya_user_ws_registered, storage):
+    remove(ya_user_ws_registered)
 
-    assert ya_user_ws_authenticated not in storage.authenticated_connections
-    assert ws_subscribed in storage.authenticated_connections
-    assert storage.user_connections["user1"].connections == [ws_subscribed]
+    assert ya_user_ws_registered not in storage.registered_websockets
+    assert ws_subscribed in storage.registered_websockets
+    assert storage.user_connections["user1"].websockets == [ws_subscribed]
     assert storage.user_connections["user1"].user_subscriptions
     assert len(storage.subscriptions) == 1
 
 
-def test_do_not_fail_if_ws_connection_not_authenticated(remove, ws_connection):
+def test_do_not_fail_if_ws_connection_not_registered(remove, ws):
     with does_not_raise():
-        remove(ws_connection)
+        remove(ws)

--- a/src/storage/tests/storage_updaters/tests_storage_connection_remover.py
+++ b/src/storage/tests/storage_updaters/tests_storage_connection_remover.py
@@ -1,0 +1,56 @@
+from contextlib import nullcontext as does_not_raise
+import pytest
+
+from storage.storage_updaters import StorageConnectionRemover
+
+
+@pytest.fixture
+def ws_subscribed(ws_authenticated, subscribe_ws, subscription_fqi):
+    subscribe_ws(ws_authenticated, subscription_fqi)
+    return ws_authenticated
+
+
+@pytest.fixture
+def ya_user_ws_authenticated(ya_ws_connection, ya_user_valid_token, authenticate_ws):
+    authenticate_ws(ya_ws_connection, ya_user_valid_token)
+    return ya_ws_connection
+
+
+@pytest.fixture
+def remove(storage):
+    return lambda ws_connection: StorageConnectionRemover(storage, ws_connection)()
+
+
+def test_remove_connection_and_subscriptions_from_storage(remove, ws_subscribed, storage):
+    remove(ws_subscribed)
+
+    assert storage.authenticated_connections == {}
+    assert storage.user_connections == {}
+    assert storage.subscriptions == {}
+
+
+def test_do_not_remove_subscriptions_if_other_user_connections_exist(remove, ws_subscribed, ya_ws_connection, storage, ya_valid_token, authenticate_ws):
+    authenticate_ws(ya_ws_connection, ya_valid_token)  # same user, other ws connection
+
+    remove(ws_subscribed)
+
+    assert len(storage.authenticated_connections) == 1
+    assert ya_ws_connection in storage.authenticated_connections
+    assert storage.user_connections["user1"].connections == [ya_ws_connection]
+    assert storage.user_connections["user1"].user_subscriptions
+    assert len(storage.subscriptions) == 1
+
+
+def test_do_not_remove_subscriptions_other_user(remove, ws_subscribed, ya_user_ws_authenticated, storage):
+    remove(ya_user_ws_authenticated)
+
+    assert ya_user_ws_authenticated not in storage.authenticated_connections
+    assert ws_subscribed in storage.authenticated_connections
+    assert storage.user_connections["user1"].connections == [ws_subscribed]
+    assert storage.user_connections["user1"].user_subscriptions
+    assert len(storage.subscriptions) == 1
+
+
+def test_do_not_fail_if_ws_connection_not_authenticated(remove, ws_connection):
+    with does_not_raise():
+        remove(ws_connection)

--- a/src/storage/tests/storage_updaters/tests_storage_user_subscriber.py
+++ b/src/storage/tests/storage_updaters/tests_storage_user_subscriber.py
@@ -1,0 +1,122 @@
+import pytest
+
+from storage.exceptions import StorageOperationException
+from storage.storage_updaters import StorageUserSubscriber
+from storage.types import SubscriptionFullQualifiedIdentifier
+
+
+@pytest.fixture
+def ya_ws_same_user_authenticated(ya_ws_connection, ya_valid_token, authenticate_ws):
+    authenticate_ws(ya_ws_connection, ya_valid_token)
+    return ya_ws_connection
+
+
+@pytest.fixture
+def ya_user_ws_authenticated(ya_ws_connection, ya_user_valid_token, authenticate_ws):
+    authenticate_ws(ya_ws_connection, ya_user_valid_token)
+    return ya_ws_connection
+
+
+@pytest.fixture
+def subscribe(storage):
+    def subscribe_user(ws, subscription_fqi):
+        return StorageUserSubscriber(
+            storage=storage,
+            websocket=ws,
+            subscription_fqi=subscription_fqi,
+        )()
+
+    return subscribe_user
+
+
+def test_create_subscription_in_storage_subscriptions(ws_authenticated, subscribe, storage, event, event_subscription_identifier, subscription_fqi):
+    subscribe(ws_authenticated, subscription_fqi)
+
+    assert event in storage.subscriptions, "Event should be created in storage"
+    assert event_subscription_identifier in storage.subscriptions[event], "Identifier should be created"
+    assert storage.subscriptions[event][event_subscription_identifier] == {"user1"}, "User id should be added to subscription"
+    assert storage.user_connections["user1"].user_subscriptions == {subscription_fqi}, "Subscription should be added to user subscriptions"
+
+
+def test_subscription_with_same_params_idempotent(ws_authenticated, subscribe, storage, subscription_fqi, event, event_subscription_identifier):
+    subscribe(ws_authenticated, subscription_fqi)
+    subscribe(ws_authenticated, subscription_fqi)
+
+    assert len(storage.subscriptions) == 1
+    assert len(storage.subscriptions[event]) == 1
+    assert len(storage.subscriptions[event][event_subscription_identifier]) == 1
+    assert storage.subscriptions[event][event_subscription_identifier] == {"user1"}
+    assert len(storage.user_connections["user1"].user_subscriptions) == 1
+
+
+def test_subscription_same_user_other_connection_idempotent(
+    ws_authenticated, ya_ws_same_user_authenticated, subscribe, storage, subscription_fqi, event, event_subscription_identifier
+):
+    subscribe(ws_authenticated, subscription_fqi)
+
+    subscribe(ya_ws_same_user_authenticated, subscription_fqi)
+
+    assert len(storage.subscriptions) == 1
+    assert len(storage.subscriptions[event]) == 1
+    assert storage.subscriptions[event][event_subscription_identifier] == {"user1"}
+    assert len(storage.user_connections["user1"].user_subscriptions) == 1
+
+
+def test_subscription_to_same_event_other_identifier(ws_authenticated, subscribe, storage, event, event_subscription_key, subscription_fqi):
+    same_event_fqi = SubscriptionFullQualifiedIdentifier(event, event_subscription_key, ("userY",))
+    subscribe(ws_authenticated, subscription_fqi)
+
+    subscribe(ws_authenticated, same_event_fqi)
+
+    assert len(storage.subscriptions) == 1
+    assert len(storage.subscriptions[event]) == 2
+    assert storage.subscriptions[event][("userX",)] == {"user1"}
+    assert storage.subscriptions[event][("userY",)] == {"user1"}
+    assert storage.user_connections["user1"].user_subscriptions == {subscription_fqi, same_event_fqi}
+
+
+def test_subscription_two_different_events(ws_authenticated, subscribe, storage, subscription_fqi, event, event_subscription_identifier):
+    other_event_fqi = SubscriptionFullQualifiedIdentifier("classifierId", ("userId", "projectUrn"), ("user008", "some-urn"))
+    subscribe(ws_authenticated, subscription_fqi)
+
+    subscribe(ws_authenticated, other_event_fqi)
+
+    assert len(storage.subscriptions) == 2
+    assert storage.subscriptions[event][event_subscription_identifier] == {"user1"}
+    assert storage.subscriptions["classifierId"][("user008", "some-urn")] == {"user1"}
+    assert storage.user_connections["user1"].user_subscriptions == {subscription_fqi, other_event_fqi}
+
+
+def test_other_user_with_same_fqi_subscribe_ok(
+    ws_authenticated, ya_user_ws_authenticated, subscribe, storage, subscription_fqi, event, event_subscription_identifier
+):
+    subscribe(ws_authenticated, subscription_fqi)
+
+    subscribe(ya_user_ws_authenticated, subscription_fqi)
+
+    assert storage.subscriptions[event][event_subscription_identifier] == {"user1", "user2"}
+    assert storage.user_connections["user1"].user_subscriptions == {subscription_fqi}
+    assert storage.user_connections["user2"].user_subscriptions == {subscription_fqi}
+
+
+def test_other_user_subscription_to_other_event_ok(
+    ws_authenticated, ya_user_ws_authenticated, subscribe, storage, subscription_fqi, event, event_subscription_identifier
+):
+    ya_subscribe_fqi = SubscriptionFullQualifiedIdentifier("classifierId", ("entityId"), (100500,))
+    subscribe(ws_authenticated, subscription_fqi)
+
+    subscribe(ya_user_ws_authenticated, ya_subscribe_fqi)
+
+    assert len(storage.subscriptions) == 2
+    assert storage.subscriptions[event][event_subscription_identifier] == {"user1"}
+    assert storage.subscriptions["classifierId"][(100500,)] == {"user2"}
+    assert storage.user_connections["user1"].user_subscriptions == {subscription_fqi}
+    assert storage.user_connections["user2"].user_subscriptions == {ya_subscribe_fqi}
+
+
+def test_raise_if_ws_connection_not_authenticated(ws_connection, subscribe, storage, subscription_fqi):
+    with pytest.raises(StorageOperationException, match="The user is not authenticated"):
+        subscribe(ws_connection, subscription_fqi)
+
+    assert storage.subscriptions == {}
+    assert storage.user_connections == {}

--- a/src/storage/tests/storage_updaters/tests_storage_user_unsubscriber.py
+++ b/src/storage/tests/storage_updaters/tests_storage_user_unsubscriber.py
@@ -1,0 +1,63 @@
+import pytest
+
+from storage.exceptions import StorageOperationException
+from storage.storage_updaters import StorageUserUnsubscriber
+from storage.types import SubscriptionFullQualifiedIdentifier
+
+
+@pytest.fixture
+def ws_subscribed(ws_authenticated, subscribe_ws, subscription_fqi):
+    subscribe_ws(ws_authenticated, subscription_fqi)
+    return ws_authenticated
+
+
+@pytest.fixture
+def unsubscribe(storage):
+    def unsubscribe_user(ws, subscription_fqi):
+        StorageUserUnsubscriber(
+            storage=storage,
+            websocket=ws,
+            subscription_fqi=subscription_fqi,
+        )()
+
+    return unsubscribe_user
+
+
+def test_unsubscribe_user_and_clear_subscriptions(unsubscribe, ws_subscribed, storage, subscription_fqi):
+    unsubscribe(ws_subscribed, subscription_fqi)
+
+    assert storage.subscriptions == {}, "Subscription keys and all internal structures should be removed"
+    assert storage.user_connections["user1"].user_subscriptions == set(), "User subscriptions should be removed"
+
+
+def test_user_unsubscribe_same_event_other_identifier(unsubscribe, subscribe_ws, ws_subscribed, storage, subscription_fqi, event, event_subscription_key):
+    same_event_ya_identifier_fqi = SubscriptionFullQualifiedIdentifier(event, event_subscription_key, ("userY",))
+    subscribe_ws(ws_subscribed, same_event_ya_identifier_fqi)
+
+    unsubscribe(ws_subscribed, subscription_fqi)
+
+    assert len(storage.subscriptions) == 1
+    assert len(storage.subscriptions[event]) == 1
+    assert storage.subscriptions[event][("userY"),] == {"user1"}
+    assert storage.user_connections["user1"].user_subscriptions == {same_event_ya_identifier_fqi}
+
+
+def test_same_user_other_subscription_key_unsubscribe_ok(unsubscribe, subscribe_ws, ws_subscribed, storage, subscription_fqi):
+    other_event_fqi = SubscriptionFullQualifiedIdentifier("classifierId", ("entityId", "userId"), (100500, "userZ"))
+    subscribe_ws(ws_subscribed, other_event_fqi)
+
+    unsubscribe(ws_subscribed, subscription_fqi)
+
+    assert len(storage.subscriptions) == 1
+    assert "classifierId" in storage.subscriptions
+    assert storage.subscriptions["classifierId"][100500, "userZ"] == {"user1"}
+    assert storage.user_connections["user1"].user_subscriptions == {other_event_fqi}
+
+
+@pytest.mark.usefixtures("ws_subscribed")
+def test_raise_if_user_not_authenticated(unsubscribe, ya_ws_connection, storage, subscription_fqi):
+    with pytest.raises(StorageOperationException, match="The user is not authenticated"):
+        unsubscribe(ya_ws_connection, subscription_fqi)
+
+    assert len(storage.subscriptions) == 1, "Should not changed"
+    assert len(storage.user_connections["user1"].user_subscriptions) == 1, "Should not changed"

--- a/src/storage/tests/storage_updaters/tests_storage_user_unsubscriber.py
+++ b/src/storage/tests/storage_updaters/tests_storage_user_unsubscriber.py
@@ -6,12 +6,6 @@ from storage.types import SubscriptionFullQualifiedIdentifier
 
 
 @pytest.fixture
-def ws_subscribed(ws_authenticated, subscribe_ws, subscription_fqi):
-    subscribe_ws(ws_authenticated, subscription_fqi)
-    return ws_authenticated
-
-
-@pytest.fixture
 def unsubscribe(storage):
     def unsubscribe_user(ws, subscription_fqi):
         StorageUserUnsubscriber(
@@ -55,9 +49,9 @@ def test_same_user_other_subscription_key_unsubscribe_ok(unsubscribe, subscribe_
 
 
 @pytest.mark.usefixtures("ws_subscribed")
-def test_raise_if_user_not_authenticated(unsubscribe, ya_ws_connection, storage, subscription_fqi):
-    with pytest.raises(StorageOperationException, match="The user is not authenticated"):
-        unsubscribe(ya_ws_connection, subscription_fqi)
+def test_raise_if_user_not_registered(unsubscribe, ya_ws, storage, subscription_fqi):
+    with pytest.raises(StorageOperationException, match="The user is not registered"):
+        unsubscribe(ya_ws, subscription_fqi)
 
     assert len(storage.subscriptions) == 1, "Should not changed"
     assert len(storage.user_connections["user1"].user_subscriptions) == 1, "Should not changed"

--- a/src/storage/types.py
+++ b/src/storage/types.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from typing import NamedTuple
+
+from websockets.server import WebSocketServerProtocol
+
+from app.types import Event
+from app.types import UserId
+
+
+@dataclass
+class WebSocketMeta:
+    """Data to store with websocket connection to identify it and to be able to close it needed.
+
+    Expiration timestamp should be updated on each authentication message with updated token.
+    """
+
+    user_id: UserId
+    expiration_timestamp: int
+
+
+EventSubscriptionKey = tuple[str, ...]  # ordered keys used to subscribe to specific event
+EventSubscriptionIdentifier = tuple[int | str, ...]  # values matched to subscription key
+EventSubscriptionsBucket = dict[EventSubscriptionIdentifier, set[UserId]]  # bucket of subscriptions for specific event
+
+
+class SubscriptionFullQualifiedIdentifier(NamedTuple):
+    """Necessary and sufficient data to create user subscription in storage."""
+
+    event: Event
+    subscription_key: EventSubscriptionKey
+    subscription_identifier: EventSubscriptionIdentifier
+
+
+class ConnectedUserMeta(NamedTuple):
+    """Data related to exact user."""
+
+    websockets: list[WebSocketServerProtocol]
+    user_subscriptions: set[SubscriptionFullQualifiedIdentifier]


### PR DESCRIPTION
Сторадж для хранения подписок Webockets.

Идея:
1. Один пользователь может иметь несколько подключений. Если сделал изменение в одном подключнии, то оно должно отразиться на остальные. Поэтому подписки прявязываются к пользователю, а не вебсокету
2. Регистрировать и "разрегистрирвать" нужно уметь на уровне вебсокета. Если вебсокет юзера прислал новые данные с токеном, то они должны обновиться только для него.

1. Подписки на события включают в себя:
     1. Название события
     2. Ключи на которые подписываются
     3. Идентификатор подписки — значения ключей на которые подписались
